### PR TITLE
cupy.util doesn't exist anymore.

### DIFF
--- a/torchpq/kmeans/kernels/CustomKernel.py
+++ b/torchpq/kmeans/kernels/CustomKernel.py
@@ -1,7 +1,7 @@
 import cupy as cp
 import torch
 
-@cp.util.memoize(for_each_device=True)
+@cp.memoize(for_each_device=True)
 def cunnex(func_name, func_body):
   return cp.cuda.compile_with_cache(func_body).get_function(func_name)
   # return cp.cuda.compile_with_cache(globals()[strFunction]).get_function(strFunction)


### PR DESCRIPTION
When getting the latest version of cupy with pip I get an error saying that cupy.util doesn't exist.  
The function seems to have been moved: https://docs.cupy.dev/en/stable/reference/generated/cupy.memoize.html