### PR TITLE
remove .util from cupy decorator and bump version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup, find_packages
 setup(
   name = 'torchpq',
   packages = find_packages(),
-  version = '0.1.8.1',
+  version = '0.1.8.2',
   license='MIT',
   description = 'Efficient implementations of Product Quantization and its variants',
   author = 'demoriarty', 
   author_email = 'sahbanjan@gmail.com',
   url = 'https://github.com/DeMoriarty/TorchPQ',
-  download_url = 'https://github.com/DeMoriarty/TorchPQ/archive/v_0181.tar.gz',
+  download_url = 'https://github.com/DeMoriarty/TorchPQ/archive/v_0182.tar.gz',
   keywords = ['KMeans', 'K-means', 'ANN', 'pytorch','machine learning', 'pq', 'product quantization', 'IVFPQ', 'approximate nearest neighbors'],
   install_requires=[ 
     'numpy',

--- a/torchpq/kernels/CustomKernel.py
+++ b/torchpq/kernels/CustomKernel.py
@@ -1,7 +1,7 @@
 import cupy as cp
 import torch
 
-@cp.util.memoize(for_each_device=True)
+@cp.memoize(for_each_device=True)
 def cunnex(func_name, func_body):
   return cp.cuda.compile_with_cache(func_body).get_function(func_name)
 


### PR DESCRIPTION
pip install is not picking up @francisr's changes and he missed one of the other cp.util decorators which causes the following error when trying to import torchpq with cupy-cuda112:
`AttributeError: module 'cupy' has no attribute 'util'`

@DeMoriarty could you ensure the pip package is updated with this pull request please? Thanks!